### PR TITLE
ci: adjust to monitor main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build & Smoke Test TrinityCore-Docker
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
The main branch has been renamed using the github webui to `main`.